### PR TITLE
Switch to `files` session driver

### DIFF
--- a/roles/blog+catalog/tasks/main.yml
+++ b/roles/blog+catalog/tasks/main.yml
@@ -46,6 +46,14 @@
     version: master
     force: yes
 
+- name: CodeIgniter sessions directory
+  file:
+    path: /tmp/php-sessions
+    state: directory
+    owner: www-data
+    group: librivox
+    mode: 0700
+
 - name: Config files
   template:
     src: "{{ item }}.php"

--- a/roles/blog+catalog/templates/config.php
+++ b/roles/blog+catalog/templates/config.php
@@ -268,8 +268,8 @@ $config['encryption_key'] = '{{ codeigniter_encryption_key }}';
 | 'sess_time_to_update'		= how many seconds between CI refreshing Session Information
 |
 */
-$config['sess_driver']          = 'memcached';
-$config['sess_save_path']       = 'localhost:11211';
+$config['sess_driver']          = 'files';
+$config['sess_save_path']       = '/tmp/php-sessions';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
In CodeIgniter 2, sessions were stored in client-side encrypted
cookies [1]. This means we need to pick a session driver to store
sessions server-size. We initially went with memcache, but issue #7 is
reporting that it's not working too well.

We can switch to the `files` driver and store sessions in
`/tmp/php-sessions` on the `/tmp` `tmpfs` filesystem, but this
introduces another issue, wherein empty session files fill up the
directory and actually hit the files per directory limit, preventing
anything else from creating files in `/tmp`.

As a stop-gap, we add a cronjob to clean up empty session files (which
are the *vast* majority), but this is obviously an ugly hack, and we
should get to the bottom of what's happening.

[1] https://codeigniter.com/userguide3/installation/upgrade_300.html#step-6-update-your-session-library-usage