### PR TITLE
Fix #3 - Restart Apache on certbot-issue

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -174,6 +174,7 @@
 
 - name: Run certbot-issue
   command: /librivox/bin/certbot-issue
+  notify: Restart Apache
   become: true
   when: "'production' in inventory_file"
 


### PR DESCRIPTION
Fixes one cause of issue as described in #3 
Though, the "Renew cronjob" with "--post-hook 'systemctl restart apache2'" should _also_ be restarting Apache when that runs, so if this is still happening, there's another issue.