### PR TITLE
[WIP] Localdev doc

### DIFF
--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -80,7 +80,7 @@ Therefore, install Ansible from source.
     git clone https://github.com/librivox/librivox-ansible
     cd librivox-ansible
 
-    ipaddr=$(ifconfig | perl -ne 'printf("%s\n", $1) if /^\s+inet addr:\s*(\S+)/ && $1 ne "127.0.0.1"')
+    ipaddr=$(hostname -I)
     printf '[server]\n%s\n' "$ipaddr" > hosts/localdev/hosts
 
 Do not let Git overwrite the local changes when updating:

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -80,7 +80,7 @@ Therefore, install Ansible from source.
     git clone https://github.com/librivox/librivox-ansible
     cd librivox-ansible
 
-    ipaddr=$(hostname -I)
+    ipaddr=$(hostname -I | cut -d' ' -f1)
     printf '[server]\n%s\n' "$ipaddr" > hosts/localdev/hosts
 
 Do not let Git overwrite the local changes when updating:

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -92,7 +92,7 @@ Do not let Git overwrite the local changes when updating:
 
 ## Let the playbook run
 
-    ansible deploy.yml -i hosts/localdev/hosts
+    ansible-playbook deploy.yml -i hosts/localdev/hosts
 
 ## Access LibriVox from the host system
 

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -39,7 +39,7 @@ To make this easy, give your user complete root permissions without password.
 After all, this is just in a virtual machine in a private environment,
 so convenience is more important than security.
 
-    echo "$USER ALL=(ALL:ALL) NOPASSWD: ALL" > "/etc/sudoers.d/$USER"
+    echo "$USER ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee "/etc/sudoers.d/$USER"
 
 ## Disable IPv6
 

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -30,7 +30,7 @@ Download and install VirtualBox 5.2.8.
     * 50 GB dynamic disk space
     * Bridged networking
 * Install Ubuntu in that VM
-    * Select all feature sets
+    * Select OpenSSH server package set, along with 'standard system utilities'
 
 ## Easy root privileges
 

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -63,15 +63,12 @@ But if you get a network timeout, disable IPv6 networking:
 
 ## Ansible
 
-LibriVox requires Ansible >= 2.4, while Ubuntu comes with 2.0.
-Therefore, install Ansible from source.
+LibriVox requires Ansible >= 2.4, while Ubuntu 16.04 comes with 2.0.
+Therefore, install Ansible from PPA.
 
-    mkdir git
-    cd git
-    git clone https://github.com/ansible/ansible
-    cd ansible
-    python setup.py build
-    python setup.py install --user
+    sudo apt-add-repository ppa:ansible/ansible
+    sudo apt update
+    sudo apt install ansible
     ansible --version
 
 ## Adjust LibriVox playbook for local development

--- a/doc/localdev.md
+++ b/doc/localdev.md
@@ -115,8 +115,9 @@ To browse the LibriVox databases from the IDE, add a MySQL user:
 
 ### Initialize the catalog database
 
+    bunzip2 -k roles/blog+catalog/files/librivox_catalog_scrubbed.sql.bz2 > /tmp/librivox_catalog_scrubbed.sql
     mysql -ulibrivox -plibrivox -e 'CREATE DATABASE librivox_catalog'
-    mysql -ulibrivox -plibrivox librivox_catalog < roles/blog+catalog/files/librivox_catalog.schema.sql
+    mysql -ulibrivox -plibrivox librivox_catalog < /tmp/librivox_catalog_scrubbed.sql
 
 ### Share folders
 


### PR DESCRIPTION
Since I'm learning this already, I may as well get it posted!

- Updated instructions for manually importing the scrubbed blog+catalog db.  I see a handler for automating this, but have yet to get that working.  Maybe need to add 'localdev' to /etc/ansible/hosts?
- Looks like the scrubber sets all account passwords to some default value I don't see in the code.  Should we know this, or should I be figuring out how to override passwords in the db?
- I've disabled the SSH port change task on my end, rather than reconfigure Ansible's connection.
- I've also disabled mp3gain installation for my own local testing.  No luck with the PPA so far, though I see it exists.  Might need to switch to the snap package.

#11 is a placeholder for this.