### PR TITLE
Add wiki_smtp_password for localdev

### DIFF
--- a/localdev.yaml
+++ b/localdev.yaml
@@ -10,6 +10,7 @@ forum_db_password: librivox_forum
 wiki_db_password: mediawiki
 wiki_secret_key: wiki_secret_key
 wiki_upgrade_key: wiki_upgrade_key
+wiki_smtp_password: wiki_smtp_password
 blog_wp_salt: |
   define('AUTH_KEY',         'put your unique phrase here');
   define('SECURE_AUTH_KEY',  'put your unique phrase here');


### PR DESCRIPTION
Hi! It looks like the `wiki_smtp_password` added in 0d76699 wasn't added to `localdev.yaml`, unless there's some other way I should be populating that?

Thanks!