### PR TITLE
Run DB migrate command for localdev DB import

### DIFF
--- a/roles/db_import/tasks/main.yaml
+++ b/roles/db_import/tasks/main.yaml
@@ -11,3 +11,6 @@
     target: /tmp/librivox_catalog_scrubbed.sql.bz2
     login_user: catalog
     login_password: '{{ catalog_db_password }}'
+
+- name: Migrate database
+  command: php /librivox/www/librivox.org/catalog/public_html/index.php migrate migrate


### PR DESCRIPTION
Following up on https://github.com/LibriVox/librivox-catalog/pull/213,
run the DB migrate command to enable CI to pass when DB schema changes
are needed.
