### PR TITLE
Use ACF GitHub releases URL

### DIFF
--- a/roles/acf_free/tasks/main.yaml
+++ b/roles/acf_free/tasks/main.yaml
@@ -2,6 +2,6 @@
 # have the repeater field we need, but it's better than nothing.
 - name: Install ACF free
   unarchive:
-    src: "https://downloads.wordpress.org/plugin/advanced-custom-fields.{{ acf_version }}.zip"
+    src: "https://github.com/AdvancedCustomFields/acf/releases/download/{{ acf_version }}/advanced-custom-fields-{{ acf_version }}.zip"
     dest: /librivox/www/librivox.org/wordpress/wp-content/plugins
     remote_src: yes


### PR DESCRIPTION
Since WordPress took over ACF [1], the plugin's page on wordpress.org
has been renamed Secure Custom Fields. Start using the zip from GitHub
releases to install ACF Free.

[1] https://techcrunch.com/2024/10/12/in-latest-move-against-wp-engine-wordpress-takes-control-of-acf-plugin/
