### PR TITLE
Initial rate-limiting setup with mod_qos

### DIFF
--- a/roles/common/files/qos.conf
+++ b/roles/common/files/qos.conf
@@ -1,0 +1,122 @@
+<IfModule qos_module>
+
+  ### Docs
+
+  ## This file is MOSTLY a set of limits that are applied to specific requests.  The requests are tagged with
+  #  counters like "ForumPage_PerIP_Short".  We use "Page" to mean an actual page that the user requests, rather than
+  #  a JS/CSS resource or an image.  We have separate _Short, _Med, and _Long counters so that we can have high
+  #  "burst" limits, which go down to more sustainable rates over longer time-frames.
+
+  ## Official manual for mod_qos:
+  #  https://mod-qos.sourceforge.net/
+  
+  ## ...and a blog post with a simple usage example, and some helpful comments:
+  #  https://ionica.ca/2021/08/24/mitigating-denial-of-service-attacks-with-mod_qos/
+
+  ## There's a "VIP" feature we might consider using in future.  As-is, our applications don't offer a reliable way
+  #  for mod_qos to check for "VIP" status, so we work from the opposite direction, giving generous(?) limits to
+  #  everyone, and then tightening things down where we can.
+  #  https://mod-qos.sourceforge.net/#privilegedusers
+  ### /Docs
+
+
+  ### Housekeeping
+
+  ## Return this status code when blocking a request
+  QS_ErrorResponseCode		429
+
+  ## Save logs of request rates, response times, and response status codes over time.
+  #QSLog "|/usr/bin/qslog -o /var/log/apache2/qos.log.csv"
+
+  ## Track stats for this number of clients.  It seems that less active clients will "roll off" the list over time.
+  #  Default is 50000.
+  #QS_ClientEntries		50000
+  ### /Housekeeping
+
+
+  ### TCP stream limits - close extra connections when we're busy
+
+  ## Defines the maximum allowed number of concurrent TCP connections for this server.
+  #  I'm not sure how this differs from MaxRequestWorkers (in mods-enabled/mpm_event.conf) which is set from Ansible
+  #QS_SrvMaxConn			300
+
+  ## Allows keep-alive support till the server reaches this number of connections.
+  #  When given as a percentage, it is explicitly relative to MaxRequestWorkers.
+  QS_SrvMaxConnClose		80%
+
+  ## The maximum number of TCP connection streams allowed to stay open from a single IP, at any given time.
+  #  As the number of existing connections (load) goes up, reduce the limit.  Firefox and Chromium both work fine
+  #  with 10 connection streams, even with nothing in cache.  Below that, new visitors will have trouble.
+  #				conn	load
+  QS_SrvMaxConnPerIP		30
+  QS_SrvMaxConnPerIP		15	200
+  QS_SrvMaxConnPerIP		10	275
+  ### /TCP stream limits
+
+
+  ### Server-wide page limits - not to be used for light-weight files and images!
+
+  ## Slow-down after a burst
+  #  After allowing an initial burst, the next requests with this counter *may* have a slight delay added, rather
+  #  than being blocked.  On a busy server, it should nudge clients toward this average rate of requests, over time.
+  # Use: QS_Event		avg
+  QS_ClientEventPerSecLimit	3
+
+  ## Persistent blocks for persistent clients
+  #  Requests with this counter will be blocked if they exceed the limit.  Unlike the others, this might actually
+  #  close the TCP connection, and future requests with this counter will *reset* the counter, if they are still
+  #  within the blocking window.
+  # Use: QS_Block		req	sec
+  QS_ClientEventBlockCount	60	30
+
+  ## Limit paralel requests by the same client
+  #  Requests with this flag set will be run only once (per client) at any given time.
+  # Use: QS_Serialize
+  QS_ClientSerialize
+  ### /Server-wide page limits
+
+
+  ### Forum limits - using counters as set in forum.librivox.org.conf
+
+  ## Page requests - should not apply to logged-in users
+  #  Concurrent guest page load limit (in normal operation, this is way more permissive than "X per second", since requests should be fast)
+  QS_EventRequestLimit		ForumPage_Guests_Concurrent	250
+  #  Per-user (or per-IP)	req	sec	counter
+  QS_ClientEventLimitCount	4	1	ForumPage_PerIP_Short
+  QS_ClientEventLimitCount	8	20	ForumPage_PerIP_Med
+  QS_ClientEventLimitCount	24	180	ForumPage_PerIP_Long
+
+  ## Resource file requests (CSS/JS) - should soon be in client caches, so we use a 1x2x4 pattern for the lengthening time-frames
+  #  All-user limit
+  #QS_EventRequestLimit		ForumRes_All_Concurrent	50
+  #  Per-user (or per-IP)	req	sec	counter
+  QS_ClientEventLimitCount	30	1	ForumRes_PerIP_Short
+  QS_ClientEventLimitCount	60	10	ForumRes_PerIP_Med
+  QS_ClientEventLimitCount	120	120	ForumRes_PerIP_Long
+
+  ## Image requests (decorations, but mainly emojis) - should soon be in client caches, so we use a 1x2x4 pattern for the lengthening time-frames
+  #  All-user limit
+  QS_EventRequestLimit		ForumImg_All_Concurrent	25
+  #  Per-user (or per-IP)	req	sec	counter
+  QS_ClientEventLimitCount	65	1	ForumImg_PerIP_Short
+  QS_ClientEventLimitCount	130	10	ForumImg_PerIP_Med
+  QS_ClientEventLimitCount	260	120	ForumImg_PerIP_Long
+  ### /Forum limits
+
+  ## Limits for POST requests (login attempts, posting and previewing messages, or moderation actions)
+  #  All-user limit - Note: these requests are also marked with QS_Serialize, so each user can only do one at a time.
+  #QS_EventRequestLimit		ForumPost_All_Concurrent	5
+
+  #  Posts by logged-in users
+  #  Per-user (or per-IP)	req	sec	counter
+  QS_ClientEventLimitCount	3	3	ForumPost_PerIP_Short
+  QS_ClientEventLimitCount	6	12	ForumPost_PerIP_Med
+  QS_ClientEventLimitCount	20	60	ForumPost_PerIP_Long
+
+  #  Login attempts (we can be somewhat harsher on repeats)
+  #  Per-user (or per-IP)	req	sec	counter
+  QS_ClientEventLimitCount	12	60	ForumLogin_PerIP_Med
+  QS_ClientEventLimitCount	20	1200	ForumLogin_PerIP_Long
+  ## /Forum limits
+
+</IfModule>

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -8,7 +8,8 @@
            'php8.1-mbstring', 'php8.1-xml', 'php8.1-zip', 'php8.1-apcu',
            'php8.1-bz2', 'php8.1-gd', 'php8.1-imagick',  'php8.1-xdebug',
            'php-wikidiff2', 'python3-certbot-apache', 'python3-mysqldb',
-           'sphinxsearch', 'mp3gain', 'unzip', 'memcached', 'imagemagick']
+           'sphinxsearch', 'mp3gain', 'unzip', 'memcached', 'imagemagick',
+           'libapache2-mod-qos']
     state: latest
     update_cache: yes
   become: true
@@ -83,6 +84,14 @@
   with_items:
     - ssl
     - proxy_fcgi
+    - qos
+  become: true
+  notify: Restart Apache
+
+- name: mod_qos config
+  copy:
+    src: qos.conf
+    dest: /etc/apache2/mods-available/qos.conf
   become: true
   notify: Restart Apache
 

--- a/roles/forum/templates/forum.librivox.org.conf
+++ b/roles/forum/templates/forum.librivox.org.conf
@@ -8,6 +8,8 @@
 
     DocumentRoot /librivox/www/forum.librivox.org/phpBB
 
+    ErrorLog /var/log/apache2/forum.librivox.org_error.log
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ app.php [QSA,L]
@@ -51,6 +53,51 @@
     <Directory /librivox/www/forum.librivox.org/phpBB/config>
         Require all denied
     </Directory>
+
+
+    ### Counters for rate limiting (see qos.conf)
+
+    <LocationMatch "^/(.*\.php[^(/cron)]*)?$">
+        ## Flag/counter for gentle, delay-based throttling of PHP page views (does not block, on its own)
+        SetEnv QS_Event
+
+        ## Note: phpBB rarely gives anything but a 200 OK status code, even where access is forbidden.  Instead, it shows one of several
+        #  denial messages (if logged in), or the login screen (usually, if not logged in).  Notably, it does not *redirect* to the login
+        #  page, but shows the form as if that were the legitimate content of the requested page.
+        #  For now, we can check for a single string in the response body, and this will indicate that the visitor is not logged in:
+        QS_SetEnvIfResBody '<span>Login</span>' _Is_Forum_Guest
+
+        ## Counters for PHP page views by guests
+        #  These are eligible for delays after bursts (QS_Event, set above), server-wide connection blocking (QS_Block), or just to be blocked
+        #  individually, based on how many requests there are from this client, of this type, across varying time-frames.
+        #
+        #  * Mild hack using QS_SetEnvIf (if $1 AND $2, then set $3).  It's a conditional that evaluates during the correct phase of Apache's
+        #    process (which seems to be rare...), and there does not seem to be a version of it that skips the AND part.  So, repeating.
+        QS_SetEnvIf _Is_Forum_Guest _Is_Forum_Guest QS_Block=1
+        QS_SetEnvIf _Is_Forum_Guest _Is_Forum_Guest ForumPage_Guests_Concurrent=1
+        QS_SetEnvIf _Is_Forum_Guest _Is_Forum_Guest ForumPage_PerIP_Short=1
+        QS_SetEnvIf _Is_Forum_Guest _Is_Forum_Guest ForumPage_PerIP_Med=1
+        QS_SetEnvIf _Is_Forum_Guest _Is_Forum_Guest ForumPage_PerIP_Long=1
+
+        ## Counter for POST requests (login requests, posting messages, *previewing* messages, and moderation actions)
+        #  Eligible for delays, connection blocking, or individual blocks.  The server will process only one of these, per client, at a time.
+        SetEnvIf Request_Method "POST" QS_Serialize QS_Event QS_Block _Is_Post
+        # Overall limits on posts (login, message posting, message preview, and moderation actions)
+        QS_SetEnvIf _Is_Post _Is_Post ForumPost_PerIP_Short=1
+        QS_SetEnvIf _Is_Post _Is_Post ForumPost_PerIP_Med=1
+        QS_SetEnvIf _Is_Post _Is_Post ForumPost_PerIP_Long=1
+
+        ## Additional, tighter/longer limits on POST attempts by guests
+        QS_SetEnvIf _Is_Forum_Guest _Is_Post ForumLogin_PerIP_Med=1
+        QS_SetEnvIf _Is_Forum_Guest _Is_Post ForumLogin_PerIP_Long=1
+
+    </LocationMatch>
+
+    ## Counter for important resource files - JS, CSS, logo, etc.
+    SetEnvIf Request_URI "^/[(assets)(styles)]" ForumRes_All_Concurrent ForumRes_PerIP_Short ForumRes_PerIP_Med ForumRes_PerIP_Long
+
+    ## Counter for other images - informative or emojis, lower priority
+    SetEnvIf Request_URI "^/[(images/)(favicon.ico)]" ForumImg_All_Concurrent ForumImg_PerIP_Short ForumImg_PerIP_Med ForumImg_PerIP_Long
 
 </VirtualHost>
 


### PR DESCRIPTION
This should affect just the forum, for now.  Server-wide connection and keepalive limits will apply to blog/wiki/catalog/Workflow visitors, but the other limits are just on the forum.  A few notables:
* GET requests are rate-limited by IP, though logged-in users have fewer limits there.  POST limits are more strict.
* Concurrent requests by guests/bots are limited to 250 (out of a max of 300, if I understand the relation to worker threads correctly).  That leaves some workers in reserve for logged-in users, and for the other sites on the server.
* The forum now logs errors (including blocks) to a new file.  I'd like to also turn on mod_qos's own analysis, if we have the overhead to do so.  It would show aggregate stats for connections, requests rates, response times and status codes over time.

Rate limits for the catalog (and for login attempts on Workflow) are on the agenda, but the main librivox.org.conf file needs careful picking apart for that.