### PR TITLE
Remove limit on concurrent images (across all visitors)

### DIFF
--- a/roles/common/files/qos.conf
+++ b/roles/common/files/qos.conf
@@ -96,7 +96,7 @@
 
   ## Image requests (decorations, but mainly emojis) - should soon be in client caches, so we use a 1x2x4 pattern for the lengthening time-frames
   #  All-user limit
-  QS_EventRequestLimit		ForumImg_All_Concurrent	25
+  #QS_EventRequestLimit		ForumImg_All_Concurrent	25
   #  Per-user (or per-IP)	req	sec	counter
   QS_ClientEventLimitCount	65	1	ForumImg_PerIP_Short
   QS_ClientEventLimitCount	130	10	ForumImg_PerIP_Med


### PR DESCRIPTION
This block seems to be stopping more actual users than bots.  We still have the per-IP limit on images, to mitigate any abuse.