### PR TITLE
Add response delay to Apache logs

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -95,6 +95,14 @@
   become: true
   notify: Restart Apache
 
+- name: Log format config
+  lineinfile:
+   dest: /etc/apache2/apache2.conf
+   regexp: '^LogFormat.*vhost_combined$'
+   line: 'LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %D" vhost_combined'
+  become: true
+  notify: Restart Apache
+
 # PHP
 
 - name: PHP pool configuration file


### PR DESCRIPTION
Adds "%D" to Apache [LogFormat directive](https://httpd.apache.org/docs/2.4/mod/mod_log_config.html#formats).  Everything else in the line remains unchanged from the defaults packaged in this version of Ubuntu.