### PR TITLE
Use mod_remoteip to restore original visitor IP

### DIFF
--- a/roles/common/files/remoteip.conf
+++ b/roles/common/files/remoteip.conf
@@ -1,0 +1,3 @@
+<IfModule mod_remoteip.c>
+    RemoteIPHeader CF-Connecting-IP
+</IfModule>

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -85,6 +85,7 @@
     - ssl
     - proxy_fcgi
     - qos
+    - remoteip
   become: true
   notify: Restart Apache
 
@@ -102,6 +103,20 @@
    line: 'LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %D" vhost_combined'
   become: true
   notify: Restart Apache
+
+- name: mod_remoteip config
+  copy:
+    src: remoteip.conf
+    dest: /etc/apache2/mods-available/remoteip.conf
+  become: true
+  notify: Restart Apache
+
+- name: mod_remoteip config symlink
+  file:
+    path: /etc/apache2/mods-enabled/remoteip.conf
+    state: link
+    src: /etc/apache2/mods-available/remoteip.conf
+  become: true
 
 # PHP
 


### PR DESCRIPTION
Now that we're behind Cloudflare, we're noticing that phpbb gets
confused by the essentially "random" client IPs coming from
Cloudflare's servers, and sometimes logs folks out. Fix this by
restoring the original visitor IP as documented in
https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/#mod_remoteip
